### PR TITLE
Big Sur - Fixed 'mount -uw /' trick for users. (bypass error 66)

### DIFF
--- a/payloads/patch-kexts.sh
+++ b/payloads/patch-kexts.sh
@@ -386,18 +386,6 @@ kmutilErrorCheck
 # don't believe me!
 "$VOLUME/usr/sbin/kcditto"
 
-# If $VOLUME = "/" at this point in the script, then we are running in a
-# live installation and the system volume is not booted from a snapshot.
-# Otherwise, assume snapshot booting is configured and use bless to create
-# a new snapshot. (This behavior can be refined in a future release...)
-if [ "$VOLUME" != "/" ]
-then
-    echo 'Creating new root snapshot.'
-    bless --folder "$VOLUME"/System/Library/CoreServices --bootefi --create-snapshot
-else
-    echo 'Booted directly from volume, so skipping snapshot creation.'
-fi
-
 # Try to unmount the underlying volume if it was mounted by this script.
 # (Otherwise, trying to run this script again without rebooting causes
 # errors when this script tries to mount the underlying volume a second


### PR DESCRIPTION
**The blessing is unnecessary.** 

When this snapshot is created, It cannot be deleted from a recovery terminal with 'diskutil apfs deleteSnapshot' as this blessing becomes un-purgeable. 
This breaks the trick that makes 'mount -uw /' work. (If the machine has no apfs snapshots on their root partition and has authenticated root disabled. 
I'm considering this pull request as a vital update as many developers and hackintosh users depend on this trick for development.

If it's needed for the live system patching, I would maybe recommend asking (y/n) if the user wants to create a blessing.
