### PR TITLE
Fix typo in install-setvars

### DIFF
--- a/install-setvars.sh
+++ b/install-setvars.sh
@@ -166,6 +166,7 @@ then
     echo "README for more information."
     echo
     echo "install-setvars cannot continue."
+    exit 1
 fi
 
 # Now do the actual installation


### PR DESCRIPTION
You don't want to run install-setvars right after you said it's not possible, right?