### PR TITLE
Fixed logic for 2011 iMac for BackLightFixUp, Lilu, WhateverGreen

### DIFF
--- a/payloads/patch-kexts.sh
+++ b/payloads/patch-kexts.sh
@@ -692,7 +692,7 @@ then
             INSTALL_BACKLIGHT="YES"
             # INSTALL_AGC="YES"
 
-            if [ "x$IMACUSE_OC" == "xYES" ]
+            if [ "x$IMACUSE_OC" = "xYES" ]
             then
                 echo "AppleBacklightFixup, WhateverGreen and Lilu need to be injected by OpenCore"
             else

--- a/payloads/patch-kexts.sh
+++ b/payloads/patch-kexts.sh
@@ -689,10 +689,10 @@ then
 
         elif [ "$NVIDIA" ]
         then
-            INSTALL_BACKLIGHT = "YES"
+            INSTALL_BACKLIGHT="YES"
             # INSTALL_AGC="YES"
 
-            if [ "x$IMACUSE_OC"=="xYES" ]
+            if [ "x$IMACUSE_OC" == "xYES" ]
             then
                 echo "AppleBacklightFixup, WhateverGreen and Lilu need to be injected by OpenCore"
             else


### PR DESCRIPTION
Fixed minor logic issue which cause BackLightFixup, Lilu, and WhateverGreen to not install.  Works now on 2011 27" iMac.